### PR TITLE
properties in `CALL db.index.fulltext`

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -21,8 +21,8 @@ Set up a fulltext index and specificy the custom index:
 
 [source,cypher]
 ----
-CALL db.index.fulltext.createNodeIndex("myindex", ["Articles"], ["abstract", "content"], {analyzers: "whitespace_lower"});
-CALL db.index.fulltext.createNodeIndex("myindex", ["Articles"], ["abstract", "content"], {analyzers: "synonym"});
+CALL db.index.fulltext.createNodeIndex("myindex", ["Articles"], ["abstract", "content"], {analyzer: "whitespace_lower"});
+CALL db.index.fulltext.createNodeIndex("myindex", ["Articles"], ["abstract", "content"], {analyzer: "synonym"});
 ----
 
 ## Reference of available analzyers


### PR DESCRIPTION
The property is `analyzer` and not `analyzers`. When you use `analyzers` the index is created but I think the default analyzer is used. There is no error or warning that you used a wrong/unknown property. Also, in Neo4j 3.5 you do not see what analyzer you used in `call db.indexes`.